### PR TITLE
Unnecessary time conversion for "TMx#" arg

### DIFF
--- a/ygopro-server.js
+++ b/ygopro-server.js
@@ -1340,9 +1340,6 @@
           if (time_limit < 0) {
             time_limit = 180;
           }
-          if (time_limit >= 1 && time_limit <= 60) {
-            time_limit = time_limit * 60;
-          }
           if (time_limit >= 999) {
             time_limit = 999;
           }


### PR DESCRIPTION
This argument is passed in the PSW of a room to change the time limit of a turn.
It can already be set to 0 (unlimited time), or up to 999 seconds (more than 15 minutes).
Removing this seconds-to-minutes conversion also allows for setting a time of 60 seconds or shorter, for blitz games.